### PR TITLE
fixing cidr collision issue

### DIFF
--- a/dns-resolver/_providers.tf
+++ b/dns-resolver/_providers.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    massdriver = {
+      source  = "massdriver-cloud/massdriver"
+      version = "~> 1.0"
+    }
+    utility = {
+      source = "massdriver-cloud/utility"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+    jq = {
+      source  = "massdriver-cloud/jq"
+      version = "~> 0.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+
+  client_id       = var.azure_service_principal.data.client_id
+  tenant_id       = var.azure_service_principal.data.tenant_id
+  client_secret   = var.azure_service_principal.data.client_secret
+  subscription_id = var.azure_service_principal.data.subscription_id
+}

--- a/dns-resolver/dns_resolver.tf
+++ b/dns-resolver/dns_resolver.tf
@@ -1,3 +1,9 @@
+# DNS resolver is required as this is the component that resolves DNS requests.
+# Without this, only way to connect to resources is using private IP address.
+# https://learn.microsoft.com/en-us/azure/architecture/example-scenario/networking/azure-dns-private-resolver
+
+# Multi-step build is required as there are 2 subnets provisioning in this bundle, and single step causes CIDR collision.
+
 locals {
   split_vnet_id       = split("/", var.azure_virtual_network.data.infrastructure.id)
   vnet_name           = element(local.split_vnet_id, length(local.split_vnet_id) - 1)
@@ -21,10 +27,6 @@ resource "utility_available_cidr" "dns_resolver" {
   used_cidrs = flatten([for subnet in data.azurerm_subnet.lookup : subnet.address_prefixes])
   mask       = 28
 }
-
-# DNS resolver is required as this is the component that resolves DNS requests.
-# Without this, only way to connect to resources is using private IP address.
-# https://learn.microsoft.com/en-us/azure/architecture/example-scenario/networking/azure-dns-private-resolver
 
 resource "azurerm_private_dns_resolver" "dns_resolver" {
   name                = var.md_metadata.name_prefix

--- a/dns-resolver/dns_resolver.tf
+++ b/dns-resolver/dns_resolver.tf
@@ -1,10 +1,30 @@
+locals {
+  split_vnet_id       = split("/", var.azure_virtual_network.data.infrastructure.id)
+  vnet_name           = element(local.split_vnet_id, length(local.split_vnet_id) - 1)
+  vnet_resource_group = element(local.split_vnet_id, index(local.split_vnet_id, "resourceGroups") + 1)
+}
+
+data "azurerm_virtual_network" "lookup" {
+  name                = local.vnet_name
+  resource_group_name = local.vnet_resource_group
+}
+
+data "azurerm_subnet" "lookup" {
+  for_each             = toset(data.azurerm_virtual_network.lookup.subnets)
+  name                 = each.key
+  virtual_network_name = local.vnet_name
+  resource_group_name  = local.vnet_resource_group
+}
+
 resource "utility_available_cidr" "dns_resolver" {
   from_cidrs = data.azurerm_virtual_network.lookup.address_space
   used_cidrs = flatten([for subnet in data.azurerm_subnet.lookup : subnet.address_prefixes])
   mask       = 28
 }
 
-# DNS resolver is required as this is the component that resolves DNS requests. Without this, only way to connect to resources is using private IP address. https://learn.microsoft.com/en-us/azure/architecture/example-scenario/networking/azure-dns-private-resolver
+# DNS resolver is required as this is the component that resolves DNS requests.
+# Without this, only way to connect to resources is using private IP address.
+# https://learn.microsoft.com/en-us/azure/architecture/example-scenario/networking/azure-dns-private-resolver
 
 resource "azurerm_private_dns_resolver" "dns_resolver" {
   name                = var.md_metadata.name_prefix
@@ -34,6 +54,7 @@ resource "azurerm_private_dns_resolver_inbound_endpoint" "dns_resolver" {
   private_dns_resolver_id = azurerm_private_dns_resolver.dns_resolver.id
   location                = var.azure_virtual_network.specs.azure.region
   tags                    = var.md_metadata.default_tags
+
   ip_configurations {
     private_ip_allocation_method = "Dynamic"
     subnet_id                    = azurerm_subnet.dns_resolver.id

--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -5,6 +5,12 @@ source_url: github.com/massdriver-cloud/azure-vpn-gateway
 access: public
 type: infrastructure
 
+steps:
+  - path: src
+    provisioner: terraform
+  - path: dns-resolver
+    provisioner: terraform
+
 params:
   required:
     - gateway


### PR DESCRIPTION
This fixes a CIDR collision issue between the `GatewaySubnet` and `inbounddns` subnets. Prior to this change, they deployed simultaneously (even with `depends_on` added in) and caused a collision. Breaking the deployment out into 2 steps ensures that the CIDR for the `GatewaySubnet` is assigned and consumed prior to the deployment of the `inbounddns` subnet.